### PR TITLE
Fixed bug where error would not go away on user screen when "Choosing…

### DIFF
--- a/photo-effects/src/layout/Dashboard.jsx
+++ b/photo-effects/src/layout/Dashboard.jsx
@@ -31,6 +31,9 @@ export default class Dashboard extends Component {
     const files = Array.from(e.target.files)
     console.log(files);
 
+    // this will clear the error message from the user screen
+    this.setState({ error: null })
+
     if (files.length > 1) {
       const msg = 'Only 1 images can be uploaded at a time'
       return console.log('No more than 1') 
@@ -164,7 +167,7 @@ export default class Dashboard extends Component {
       <div>
         <Logout logoutButton={this.logoutButton} />
        <h1>Welcome Username!</h1>
-       {(this.state.exist === 'true')  ? 'This is the image you want?' : 
+       {(this.state.exist === 'true' && this.state.error === 'null')  ? 'This is the image you want?' : 
        (<Upload onChange={this.onChange} inputKey={this.state.inputKey} /> )}
        {this.state.error}
        <Image images={this.state.images} removeImage={this.removeImage} updateProject={this.updateProject}/>


### PR DESCRIPTION
# Description
- Issue when user "Choose File" and chose a file that produced an error, the error would not go away even when user chose a file after it that was acceptable.
- Also fixed minor conditional rendering bug.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- Tested on local machine and on testing branch on netlify.
- Chose a file that wasn't accepted('.svg') and clicked cancel to make sure input reset and error would go away once user clicked an image that was acceptable.

